### PR TITLE
Added multi-instance feature for caffe2 predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,23 @@ Note: Caffe2 is now a part of pytorch library, so need to compile it from pytorc
 
 - Clone the `pytorch` [git repository](https://github.com/pytorch/pytorch) & compile it.
 
-- Clone the `mkl-dnn` [git repository](https://github.com/intel/mkl-dnn) & get the external header files.
+    ```Bash
+    $ git clone https://github.com/pytorch/pytorch
+    # Cloning...
+    $ cd pytorch
+    $ git checkout v1.0.1 # I currently test using this version
+    # Compile it
+    ```
+
+- (Depends on the pytorch build flags) Clone the `mkl-dnn` [git repository](https://github.com/intel/mkl-dnn) & get the external header files.
+
+    ```Bash
+    $ https://github.com/intel/mkl-dnn
+    # Cloning...
+    $ cd mkl-dnn
+    $ git checkout v0.18.1 # I currently test using this version
+    # Compile it
+    ```
 
 - Clone this repository.
 
@@ -25,21 +41,21 @@ Note: Caffe2 is now a part of pytorch library, so need to compile it from pytorc
     # Cloning...
     ```
 
-- Copy all of the `torch` package include file (should be on `torch/include/`) into `caffe2/include-pytorch/`
+- Copy all of the `torch` package include file (should be on `torch/lib/include/`) into `caffe2/include-pytorch/`
 
     ```bash
     # On pytorch directory after compilation
     $ cp -r torch/include/* /path/to/caffe2/include-pytorch/
     ```
 
-- Copy `libc10.so` & `libcaffe2.so` from `pytorch` build result (should be on `build/lib`) into `caffe2/lib/` directory.
+- Copy `libc10.so` & `libcaffe2.so` from `pytorch` build result (should be on `build/lib/`) into `caffe2/lib/` directory.
 
     ```bash
     # On pytorch directory after compilation
     $ cp build/lib/libc10.so build/lib/libcaffe2.so /path/to/caffe2/lib/
     ```
 
-- Copy all of the `mkl-dnn` external header file (should be on `external/mklxx/include/`) into `caffe2/include-mkl`
+- Copy all of the `mkl-dnn` external header file (should be on `external/mkl{xx}/include/`) into `caffe2/include-mkl`
 
     ```bash
     # On pytorch directory after compilation

--- a/app.go
+++ b/app.go
@@ -10,10 +10,53 @@ func main() {
 		panic(err)
 	}
 
-	// Predict the sentence with that Caffe2 model
-	sentence := "Sentence to predict"
-	err = model.Predict(sentence)
+	model2, err := New("basic-model.c2")
 	if err != nil {
 		panic(err)
+	}
+
+	{
+		// Predict the sentence with that Caffe2 model
+		sentence := "Sentence to predict"
+		err = model.Predict(sentence)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	{
+		// Predict the sentence with that Caffe2 model
+		sentence := "Sentence to predict"
+		err = model.Predict(sentence)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	{
+		// Predict the sentence with that Caffe2 model
+		sentence := "Sentence to predict"
+		err = model.Predict(sentence)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	{
+		// Predict the sentence with that Caffe2 model
+		sentence2 := "Second sentence to predict"
+		err = model2.Predict(sentence2)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	{
+		// Predict the sentence with that Caffe2 model
+		sentence2 := "Second sentence to predict"
+		err = model2.Predict(sentence2)
+		if err != nil {
+			panic(err)
+		}
 	}
 }

--- a/caffe2/include/caffe2-wrapper-types.hpp
+++ b/caffe2/include/caffe2-wrapper-types.hpp
@@ -5,15 +5,46 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include "caffe2/predictor/predictor_utils.h"
+
+/**
+ * Prediction size for the `cf2_predict` result array size
+ */
+#define PREDICT_RESULT_SIZE 16
+
+/**
+ * Label size for the caffe2 model output
+ */
+#define LABEL_SIZE 32
+
+/**
+ * Probability size for the caffe2 model output
+ */
+#define PROB_SIZE 8
+
+/**
+ * This struct contains the variable needed by caffe2 library for its 
+ * prediction
+ */
+struct cf2_predictor {
+
+    // each caffe2 workspace should be deleted once all the
+    // reference is gone, so we use `shared_ptr` to achive that
+    std::shared_ptr<caffe2::Workspace> workspace_ref;
+
+    // caffe2 prediction graph
+    std::shared_ptr<caffe2::NetDef> net_graph_ref;
+};
+
 /**
  * This struct will act as a return value type for the prediction
  */
-struct cf2_predict_result {
+struct cf2_predictor_result {
     
-    // `label` is the predicted label
-    char *label;
+    // the string output from caffe2 model
+    char label[LABEL_SIZE];
 
-    // `prob` is an array of label prediction probability values
-    double prob[8];
-
+    // array of prediction values of the `label`
+    double prob[PROB_SIZE];
 };

--- a/caffe2/include/caffe2-wrapper.hpp
+++ b/caffe2/include/caffe2-wrapper.hpp
@@ -5,20 +5,32 @@
 
 #pragma once
 
+#include "caffe2-wrapper-types.hpp"
+
 extern "C" {
 
     /**
-     * Initialize the caffe2 model located on `path`
-     * returns 0 on success
+     * Initialize the `predictor` with the model located on `path`
+     * 
+     * Returns status indication successful process (0 for success, fails otherwise)
      */
-    int cf2_load_model(const char *path);
+    int cf2_load_model(
+        struct cf2_predictor *predictor, 
+        const char *path
+    );
 
     /**
      * Predict a given keyword
-     * `query_in`: The actual keyword to predict
-     * `result`: An array of `predict_result` that will contain the result
-     * `result_size`: The allocation size of `result`
-     * returns 0 on success
+     * 
+     * `in` : The actual keyword to predict
+     * `out`: An array of `cf2_predictor_result` that will contains
+     *        the result
+     * 
+     * Returns 0 on success
      */
-    int cf2_predict(const char *query_in, struct cf2_predict_result *result, int result_size);
+    int cf2_predict(
+        struct cf2_predictor *predictor, 
+        const char *in, 
+        struct cf2_predictor_result out[PREDICT_RESULT_SIZE]
+    );
 }


### PR DESCRIPTION
Moved the global object `workspace` & `net_graph` into it's own structure that could be allocated by the user.